### PR TITLE
Fix web-app starting point

### DIFF
--- a/public/web-app-manifest.json
+++ b/public/web-app-manifest.json
@@ -3,7 +3,7 @@
   "short_name": "DS",
   "description": "A filterable, mobile-friendly list of shortcuts for the Synthstrom Deluge.",
   "display": "standalone",
-  "start_url": "/",
+  "start_url": "/deluge-shortcuts/",
   "lang": "en",
   "theme_color": "#222222",
   "background_color": "#eeeeee",


### PR DESCRIPTION
Hi @handeyeco I failed to set the proper starting point, so once you've installed the app, and started it up, it loads your landing page rather than the app, this fixes it. Sorry for the trouble!